### PR TITLE
Optimize event query

### DIFF
--- a/src/main/resources/db/migration/V5__Added_index_on_event_time.sql
+++ b/src/main/resources/db/migration/V5__Added_index_on_event_time.sql
@@ -1,0 +1,2 @@
+-- Using a BRIN index since the events are "almost always" inserted in chronological order
+CREATE INDEX i_event_time ON event USING BRIN (event_time);


### PR DESCRIPTION
An event query that does not specify from/to dates currently looks up back in time without any limitation. This causes performance issues as the event history grows.
This PR limits such a query to maximum 2 years back in time.