### PR TITLE
Update entur/gha-api action to v6

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,10 +51,10 @@ jobs:
 
   Openapi-lint:
     needs: [ maven-verify ]
-    uses: entur/gha-api/.github/workflows/lint.yml@v5
+    uses: entur/gha-api/.github/workflows/lint.yml@v6
     secrets: inherit
     with:
-      spec: 'src/main/resources/openapi/openapi-events-external.json'
+      path: 'src/main/resources/openapi/openapi-events-external.json'
       upload_to_bucket: ${{ github.repository_owner == 'entur' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
   docker-build:

--- a/src/main/resources/openapi/openapi-events-external.json
+++ b/src/main/resources/openapi/openapi-events-external.json
@@ -3,7 +3,12 @@
   "info": {
     "title": "Timetable events API",
     "description": "Status of a timetable data delivery",
-    "version": "1.0"
+    "version": "1.0",
+    "x-entur-metadata": {
+      "id": "timetable-delivery-status",
+      "audience": "partner",
+      "owner": "team-ror"
+    }
   },
   "servers": [
     {
@@ -21,7 +26,7 @@
   ],
   "tags": [
     {
-      "name": "TimetableDataDeliveryStatus",
+      "name": "timetable-delivery-status",
       "description": "Status of a timetable data delivery"
     }
   ],
@@ -29,7 +34,7 @@
     "/status/{codespace}/{correlationId}": {
       "get": {
         "tags": [
-          "TimetableDataDeliveryStatus"
+          "timetable-delivery-status"
         ],
         "description": "Return the status of the delivery identified by its correlation id",
         "operationId": "getDataDeliveryStatus",

--- a/src/main/resources/openapi/openapi-events-external.json
+++ b/src/main/resources/openapi/openapi-events-external.json
@@ -1,9 +1,13 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "Timetable events API",
+    "title": "Timetable Delivery Status",
     "description": "Status of a timetable data delivery",
-    "version": "1.0",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Entur",
+      "url": "https://developer.entur.org"
+    },
     "x-entur-metadata": {
       "id": "timetable-delivery-status",
       "audience": "partner",
@@ -36,6 +40,7 @@
         "tags": [
           "timetable-delivery-status"
         ],
+        "summary": "Get the status of a timetable data delivery",
         "description": "Return the status of the delivery identified by its correlation id",
         "operationId": "getDataDeliveryStatus",
         "parameters": [
@@ -43,6 +48,7 @@
             "name": "codespace",
             "in": "path",
             "required": true,
+            "description": "Codespace identifying the data provider (e.g. 'RUT').",
             "schema": {
               "type": "string"
             }
@@ -51,6 +57,7 @@
             "name": "correlationId",
             "in": "path",
             "required": true,
+            "description": "Correlation id assigned to the delivery when it was submitted.",
             "schema": {
               "type": "string"
             }
@@ -58,11 +65,16 @@
         ],
         "responses": {
           "200": {
-            "description": "default response",
+            "description": "Delivery status for the requested correlation id.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DataDeliveryStatus"
+                },
+                "example": {
+                  "state": "OK",
+                  "date": "2026-04-17T10:30:00Z",
+                  "fileName": "rut-netex_202604171030.zip"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- Bump `entur/gha-api` lint workflow from `@v5` to `@v6`
- Rename `spec:` input to `path:` (v6 breaking change)
- Add required `info.x-entur-metadata` (`id`, `audience: open`, `owner: team-ror`) to the external OpenAPI spec
- Rename the `TimetableDataDeliveryStatus` tag to `timetable-delivery-status` so it matches the `id` required by api-guidelines v3.0.0

See the [v5 → v6 migration guide](https://github.com/entur/gha-api?tab=readme-ov-file#v5---v6). Follows the same approach used in [nisaba@888560c](https://github.com/entur/nisaba/commit/888560cad970fbdd8e9336bec0c517bb60025b05) and [nisaba@9f75eeb](https://github.com/entur/nisaba/commit/9f75eeb7ccd8fc490c45fe13941df34cdf1267cf).

## Test plan
- [ ] CI `Openapi-lint` job succeeds on the PR
- [ ] `upload_to_bucket` still works on merge to `master`