### PR TITLE
Disable openApiNullable in openapi-generator config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,7 @@
                                 <java8>true</java8>
                                 <dateLibrary>java8</dateLibrary>
                                 <interfaceOnly>true</interfaceOnly>
+                                <openApiNullable>false</openApiNullable>
                             </configOptions>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary
- Pins `openApiNullable=false` in `openapi-generator-maven-plugin` configuration to preserve pre-7.21.0 behavior.
- Version 7.21.0 flipped this default to `true`, generating imports for `org.openapitools.jackson.nullable.JsonNullable`, which is not on the classpath and causes compile failures (see #583).
- The OpenAPI spec has no `nullable: true` fields, so wrapping in `JsonNullable` has no value — the explicit setting matches the previous default and is a no-op against the current generator version (7.16.0).

## Test plan
- [x] `mvn clean compile -P prettierSkip` succeeds locally.
- [ ] CI green on this PR.
- [ ] Once merged, Renovate PR #583 (bump to 7.21.0) builds successfully after rebase.