### PR TITLE
chore: remove unused commons-io and jersey-media-multipart deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <spring-cloud-gcp-dependencies.version>7.4.6</spring-cloud-gcp-dependencies.version>
         <postgis-jdbc.version>2025.1.1</postgis-jdbc.version>
         <wololo.version>0.18.1</wololo.version>
-        <commons-io.version>2.21.0</commons-io.version>
         <swagger-jersey2.version>2.2.46</swagger-jersey2.version>
         <openapi-generator-version>7.21.0</openapi-generator-version>
 
@@ -165,11 +164,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
@@ -200,12 +194,6 @@
             <artifactId>jts2geojson</artifactId>
             <version>${wololo.version}</version>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>


### PR DESCRIPTION
## Summary
- Removed `commons-io` dependency (plus its version property) — no `org.apache.commons.io.*` imports exist in the codebase.
- Removed `jersey-media-multipart` dependency — no multipart functionality is used anywhere.

## Test plan
- [x] `mvn clean verify` passes locally (85 tests, 0 failures)
- [ ] CI green