### PR TITLE
fix: add class-level @PreAuthorize to LatestUploadResource

### DIFF
--- a/src/main/java/no/rutebanken/nabu/rest/internal/LatestUploadResource.java
+++ b/src/main/java/no/rutebanken/nabu/rest/internal/LatestUploadResource.java
@@ -42,6 +42,7 @@ import static no.rutebanken.nabu.event.support.DateUtils.atDefaultZone;
 @Tags(value = {
         @Tag(name = "LatestUploadResource", description = "Latest upload resource")
 })
+@PreAuthorize("@authorizationService.isRouteDataAdmin()")
 public class LatestUploadResource {
 
     private final EventRepository eventRepository;


### PR DESCRIPTION
## Summary
- Add `@PreAuthorize("@authorizationService.isRouteDataAdmin()")` at the class level, matching the pattern used by `AdminSummaryResource`, `ChangeLogResource`, and `NotificationResource`.

## Why
`LatestUploadResource` was the only internal-admin resource without a class-level guard. The existing single method has its own method-level `@PreAuthorize("@authorizationService.canEditRouteData(#providerId)")`, which Spring Security treats as an override of the class-level annotation — so the current endpoint's authorization is unchanged. 
