### PR TITLE
Drop stale STARTED events after an action reached a terminal state

### DIFF
--- a/src/main/java/no/rutebanken/nabu/rest/internal/TimeTableJobEventResource.java
+++ b/src/main/java/no/rutebanken/nabu/rest/internal/TimeTableJobEventResource.java
@@ -40,9 +40,12 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static no.rutebanken.nabu.domain.event.JobState.ERROR_JOB_STATES;
 import static no.rutebanken.nabu.rest.mapper.EnumMapper.convertEnums;
 
 
@@ -142,6 +145,12 @@ public class TimeTableJobEventResource {
         // Map from internal Status object to Rest service JobStatusEvent object
         String correlationId = null;
         JobStatus currentAggregation = null;
+        // Actions that have already reached a terminal state (OK/FAILED/...) within the current
+        // correlation. Used to drop a STARTED/PENDING event that sorts after the terminal one,
+        // which happens when Pub/Sub delivers a service's STARTED/SUCCESS messages out of order
+        // and the relayed event times end up inverted. Without this guard such a stale STARTED
+        // would become the last event for the action and the UI would show it as still running.
+        Set<String> terminalActions = null;
 
         List<JobEvent> sortedStatusForProvider = statusForProvider.stream().sorted(Comparator.comparing(JobEvent::getCorrelationId).thenComparing(JobEvent::getEventTime)).toList();
 
@@ -150,6 +159,7 @@ public class TimeTableJobEventResource {
             if (!in.getCorrelationId().equals(correlationId)) {
 
                 correlationId = in.getCorrelationId();
+                terminalActions = new HashSet<>();
 
                 // Create new Aggregation
                 currentAggregation = new JobStatus();
@@ -160,6 +170,15 @@ public class TimeTableJobEventResource {
                 currentAggregation.setUsername(in.getUsername());
 
                 list.add(currentAggregation);
+            }
+
+            boolean terminal = JobState.OK.equals(in.getState()) || ERROR_JOB_STATES.contains(in.getState());
+            if (terminal) {
+                terminalActions.add(in.getAction());
+            } else if (terminalActions.contains(in.getAction())) {
+                // Stale non-terminal event arriving after the action already finished — skip it
+                // so it cannot clobber the terminal state or error code.
+                continue;
             }
 
             // errorCode overwritten when processing each event so that only the error code for the last event is sent.

--- a/src/test/java/no/rutebanken/nabu/rest/TimeTableJobEventResourceTest.java
+++ b/src/test/java/no/rutebanken/nabu/rest/TimeTableJobEventResourceTest.java
@@ -84,5 +84,64 @@ class TimeTableJobEventResourceTest {
         Assertions.assertEquals("pb", b.getEvents().get(2).referential);
     }
 
+    /**
+     * A service (e.g. servicelinker) emits STARTED then SUCCESS, but the relayed event times can
+     * arrive inverted when Pub/Sub delivers the two messages out of order. The OK event then has an
+     * earlier event time than the STARTED event. The aggregation must still end in OK, with the
+     * stale STARTED dropped, rather than appearing stuck at STARTED.
+     */
+    @Test
+    void staleStartedAfterTerminalIsDropped() {
+
+        List<JobEvent> rawEvents = new ArrayList<>();
+
+        Instant t0 = Instant.now().minusMillis(2000);
+
+        String action = "LINKING";
+        // event times are inverted: OK precedes STARTED
+        rawEvents.add(new JobEvent(JobEvent.JobDomain.TIMETABLE.toString(), "filename", 2L, null, action, JobState.PENDING, "c", t0.plusMillis(1), "ost"));
+        rawEvents.add(new JobEvent(JobEvent.JobDomain.TIMETABLE.toString(), "filename", 2L, null, action, JobState.OK, "c", t0.plusMillis(2), "ost"));
+        rawEvents.add(new JobEvent(JobEvent.JobDomain.TIMETABLE.toString(), "filename", 2L, null, action, JobState.STARTED, "c", t0.plusMillis(3), "ost"));
+
+        List<JobStatus> listStatus = new TimeTableJobEventResource(null, null).convert(rawEvents);
+
+        Assertions.assertEquals(1, listStatus.size());
+        JobStatus c = listStatus.getFirst();
+        Assertions.assertEquals(JobStatus.State.OK, c.getEndStatus());
+        Assertions.assertEquals(2, c.getEvents().size());
+        Assertions.assertEquals(JobStatus.State.OK, c.getEvents().getLast().state);
+    }
+
+    /**
+     * Same inversion as above, but for the FAILED terminal path: a stale STARTED arriving after a
+     * FAILED must not resurrect the action to "Started", and must not clobber the error code with
+     * the STARTED event's null.
+     */
+    @Test
+    void staleStartedAfterFailedIsDroppedAndErrorCodePreserved() {
+
+        List<JobEvent> rawEvents = new ArrayList<>();
+
+        Instant t0 = Instant.now().minusMillis(2000);
+
+        String action = "LINKING";
+        JobEvent failed = new JobEvent(JobEvent.JobDomain.TIMETABLE.toString(), "filename", 2L, null, action, JobState.FAILED, "d", t0.plusMillis(2), "ost");
+        failed.setErrorCode("OSRM timeout");
+
+        // event times are inverted: FAILED precedes STARTED
+        rawEvents.add(new JobEvent(JobEvent.JobDomain.TIMETABLE.toString(), "filename", 2L, null, action, JobState.PENDING, "d", t0.plusMillis(1), "ost"));
+        rawEvents.add(failed);
+        rawEvents.add(new JobEvent(JobEvent.JobDomain.TIMETABLE.toString(), "filename", 2L, null, action, JobState.STARTED, "d", t0.plusMillis(3), "ost"));
+
+        List<JobStatus> listStatus = new TimeTableJobEventResource(null, null).convert(rawEvents);
+
+        Assertions.assertEquals(1, listStatus.size());
+        JobStatus d = listStatus.getFirst();
+        Assertions.assertEquals(JobStatus.State.FAILED, d.getEndStatus());
+        Assertions.assertEquals(2, d.getEvents().size());
+        Assertions.assertEquals(JobStatus.State.FAILED, d.getEvents().getLast().state);
+        Assertions.assertEquals("OSRM timeout", d.getErrorCode());
+    }
+
 
 }


### PR DESCRIPTION
Defence-in-depth for inverted servicelinker event times: skip a STARTED/PENDING event for an action that already reached OK/FAILED within the same correlation, so it can't clobber the terminal state or error code.